### PR TITLE
scripts/build_cpp.sh: drop hardcoded libpython3.10.so

### DIFF
--- a/scripts/build_cpp.sh
+++ b/scripts/build_cpp.sh
@@ -12,10 +12,8 @@ else
     VENV_PYTHON="$(uv python find)"
 fi
 
-# Detect Python paths
+# Detect Python root (FindPython3 + pybind11 auto-detect the rest)
 PYTHON_ROOT=$($VENV_PYTHON -c "import sys; print(sys.base_prefix)")
-PYTHON_INCLUDE=$($VENV_PYTHON -c "import sysconfig; print(sysconfig.get_path('include'))")
-PYTHON_LIBRARY=$($VENV_PYTHON -c "import sysconfig, os; print(os.path.join(sysconfig.get_config_var('LIBDIR'), 'libpython3.10.so'))")
 
 # Build
 rm -rf "$BUILD_DIR"
@@ -25,8 +23,6 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DPython3_EXECUTABLE="$VENV_PYTHON" \
     -DPython3_ROOT_DIR="$PYTHON_ROOT" \
-    -DPython3_INCLUDE_DIR="$PYTHON_INCLUDE" \
-    -DPython3_LIBRARY="$PYTHON_LIBRARY" \
     -DFETCHCONTENT_BASE_DIR="/tmp/cmake-fetchcontent"
 cmake --build . -j$(nproc)
 


### PR DESCRIPTION
## Summary

`scripts/build_cpp.sh` forces `-DPython3_LIBRARY=$LIBDIR/libpython3.10.so`, which only works on hosts whose Python is exactly 3.10. On a fresh `uv sync` today, uv installs Python 3.11.15 by default, and the configure step fails:

```
CMake Error: Could NOT find Python3 (missing: Development Development.Embed)
  Reason given by package:
    Development: Cannot find the library
      ".../cpython-3.11.15-linux-x86_64-gnu/lib/libpython3.10.so"
```

`src/alpha_go/cpp/CMakeLists.txt` already sets `PYBIND11_FINDPYTHON ON`, so `FindPython3` can locate the include dir and library from `Python3_EXECUTABLE` alone — the explicit `-DPython3_INCLUDE_DIR` and `-DPython3_LIBRARY` flags aren't doing useful work, and one of them is actively wrong on non-3.10 Pythons.

The minimal fix is to drop both flags. Tested on Python 3.10 (unchanged behavior) and 3.11.15 (now works).

## Test plan

On a fresh checkout with `uv sync` defaulting to Python 3.11:

- [x] `bash scripts/build_cpp.sh` configures + builds clean (~30s on 12 cores).
- [x] `uv run python -c "import alpha_go_cpp; alpha_go_cpp.GoBoard(9).play(3,3)"` succeeds.
- [x] `uv run -m pytest tests/test_cpp_go.py tests/test_cpp_mcts.py tests/test_cpp_mcts_batched.py` → 43 passed, 10 skipped.