### PR TITLE
Fix duplicate go_game link in C++ extension (silences ld duplicate-library warning)

### DIFF
--- a/src/alpha_go/cpp/CMakeLists.txt
+++ b/src/alpha_go/cpp/CMakeLists.txt
@@ -63,7 +63,9 @@ target_link_libraries(mcts PUBLIC go_game)
 pybind11_add_module(alpha_go_cpp
     bindings/bindings.cpp
 )
-target_link_libraries(alpha_go_cpp PRIVATE go_game mcts)
+# mcts PUBLIC-links go_game (above), so it propagates transitively here.
+# Listing go_game again double-links it (ld: "ignoring duplicate libraries").
+target_link_libraries(alpha_go_cpp PRIVATE mcts)
 
 # Tests (Catch2)
 FetchContent_Declare(


### PR DESCRIPTION
## Summary

`mcts` already `PUBLIC`-links `go_game`:

```cmake
target_link_libraries(mcts PUBLIC go_game)
```

so `go_game` propagates transitively to anything that links `mcts`. But `alpha_go_cpp` listed **both**:

```cmake
target_link_libraries(alpha_go_cpp PRIVATE go_game mcts)
```

which double-links `go_game` and prints, on every build of the pybind extension:

```
ld: warning: ignoring duplicate libraries: 'libgo_game.a'
```

Fix: link only `mcts` — `go_game` still arrives transitively via the `PUBLIC` dependency, so there is no behavior change, just one fewer (redundant) link entry.

## Test plan

Reproduced on macOS (Python 3.11.12), driving CMake directly (clean `CMakeLists.txt`):

- **Before:** `ld: warning: ignoring duplicate libraries: 'libgo_game.a'` on every `alpha_go_cpp` link.
- **After:** 0 duplicate-library warnings.
- `go_game_test` → `All tests passed (143 assertions in 18 test cases)`.
- `uv run -m pytest tests/test_cpp_go.py tests/test_cpp_mcts.py` → 38 passed, 10 skipped (skips are checkpoint-gated).

Independent of #5/#6/#7 — touches only `src/alpha_go/cpp/CMakeLists.txt` (3 +/- 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
