### PR TITLE
perf: share immutable per-size board tables (+37% C++ MCTS sims/sec)

### DIFF
--- a/src/alpha_go/cpp/go/go_game.cpp
+++ b/src/alpha_go/cpp/go/go_game.cpp
@@ -2,33 +2,40 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <queue>
 #include <random>
 #include <unordered_set>
 
 namespace alpha_go {
 
-GoBoard::GoBoard(int size, float komi)
-    : size_(size),
-      komi_(komi),
-      board_(size * size, EMPTY),
-      neighbor_indices_(size * size),
-      neighbor_counts_(size * size),
-      zobrist_(size * size) {
-    init_neighbors();
-    init_zobrist();
-    // Empty board hash = 0 (XOR of zero stones). seen_hashes_ starts
-    // empty — the first move's resulting hash is unconditionally legal
-    // (no prior states to repeat), and the empty-board hash gets added
-    // to seen_hashes_ when the first move is played.
-}
+namespace {
 
-void GoBoard::init_zobrist() {
-    // Deterministic seed so two GoBoards with the same size hash the
-    // same board states identically. (Different seeds for different
-    // sizes since N² varies.) splitmix64 from the seed gives
-    // good-enough distributed 64-bit values for our purposes.
-    uint64_t seed = 0x9E3779B97F4A7C15ULL ^ static_cast<uint64_t>(size_);
+BoardTables build_board_tables(int size) {
+    BoardTables t;
+    const int n = size * size;
+    t.neighbor_indices.resize(n);
+    t.neighbor_counts.resize(n);
+    t.zobrist.resize(n);
+
+    for (int row = 0; row < size; ++row) {
+        for (int col = 0; col < size; ++col) {
+            int idx = row * size + col;
+            int count = 0;
+            if (row > 0)         t.neighbor_indices[idx][count++] = (row - 1) * size + col;
+            if (row < size - 1)  t.neighbor_indices[idx][count++] = (row + 1) * size + col;
+            if (col > 0)         t.neighbor_indices[idx][count++] = row * size + (col - 1);
+            if (col < size - 1)  t.neighbor_indices[idx][count++] = row * size + (col + 1);
+            t.neighbor_counts[idx] = count;
+        }
+    }
+
+    // Deterministic seed so two boards of the same size hash identically.
+    // (Different seeds per size since N² varies.) splitmix64 gives
+    // well-distributed 64-bit values.
+    uint64_t seed = 0x9E3779B97F4A7C15ULL ^ static_cast<uint64_t>(size);
     auto next = [&seed]() -> uint64_t {
         seed += 0x9E3779B97F4A7C15ULL;
         uint64_t z = seed;
@@ -36,40 +43,42 @@ void GoBoard::init_zobrist() {
         z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
         return z ^ (z >> 31);
     };
-    const int n = size_ * size_;
     for (int i = 0; i < n; ++i) {
-        zobrist_[i][EMPTY] = 0;            // empty contributes nothing
-        zobrist_[i][BLACK] = next();
-        zobrist_[i][WHITE] = next();
+        t.zobrist[i][GoBoard::EMPTY] = 0;       // empty contributes nothing
+        t.zobrist[i][GoBoard::BLACK] = next();
+        t.zobrist[i][GoBoard::WHITE] = next();
     }
+    return t;
 }
 
-void GoBoard::init_neighbors() {
-    for (int row = 0; row < size_; ++row) {
-        for (int col = 0; col < size_; ++col) {
-            int idx = flat_index(row, col);
-            int count = 0;
+}  // namespace
 
-            // Up
-            if (row > 0) {
-                neighbor_indices_[idx][count++] = flat_index(row - 1, col);
-            }
-            // Down
-            if (row < size_ - 1) {
-                neighbor_indices_[idx][count++] = flat_index(row + 1, col);
-            }
-            // Left
-            if (col > 0) {
-                neighbor_indices_[idx][count++] = flat_index(row, col - 1);
-            }
-            // Right
-            if (col < size_ - 1) {
-                neighbor_indices_[idx][count++] = flat_index(row, col + 1);
-            }
-
-            neighbor_counts_[idx] = count;
-        }
+const BoardTables& board_tables(int size) {
+    // Built once per size, then read-only for the program lifetime.
+    // GoBoard construction is the only caller (never per-copy), so the
+    // mutex is uncontended in practice; it only guards the rare
+    // first-touch insert against the leaf-parallel batched path.
+    static std::mutex mu;
+    static std::map<int, std::unique_ptr<BoardTables>> cache;
+    std::lock_guard<std::mutex> lock(mu);
+    auto it = cache.find(size);
+    if (it == cache.end()) {
+        it = cache.emplace(size,
+                            std::make_unique<BoardTables>(build_board_tables(size)))
+                 .first;
     }
+    return *it->second;
+}
+
+GoBoard::GoBoard(int size, float komi)
+    : size_(size),
+      komi_(komi),
+      board_(size * size, EMPTY),
+      tables_(&board_tables(size)) {
+    // Empty board hash = 0 (XOR of zero stones). seen_hashes_ starts
+    // empty — the first move's resulting hash is unconditionally legal
+    // (no prior states to repeat), and the empty-board hash gets added
+    // to seen_hashes_ when the first move is played.
 }
 
 std::pair<std::vector<int>, std::vector<int>> GoBoard::get_group_and_liberties(int index) const {
@@ -92,8 +101,8 @@ std::pair<std::vector<int>, std::vector<int>> GoBoard::get_group_and_liberties(i
         queue.pop();
         group.push_back(current);
 
-        for (int i = 0; i < neighbor_counts_[current]; ++i) {
-            int neighbor = neighbor_indices_[current][i];
+        for (int i = 0; i < tables_->neighbor_counts[current]; ++i) {
+            int neighbor = tables_->neighbor_indices[current][i];
 
             if (board_[neighbor] == EMPTY) {
                 if (!liberty_visited[neighbor]) {
@@ -114,7 +123,7 @@ int GoBoard::remove_group(const std::vector<int>& group) {
     for (int idx : group) {
         // XOR-out the stone's contribution from current_hash_ before
         // erasing it. Symmetric to the placement XOR in play_flat_unchecked.
-        current_hash_ ^= zobrist_[idx][board_[idx]];
+        current_hash_ ^= tables_->zobrist[idx][board_[idx]];
         board_[idx] = EMPTY;
     }
     return static_cast<int>(group.size());
@@ -164,8 +173,8 @@ bool GoBoard::is_legal_flat(int index) const {
     bool has_friendly_neighbor = false;
     bool has_empty_neighbor = false;
     bool captures_opponent = false;
-    for (int i = 0; i < neighbor_counts_[index]; ++i) {
-        int neighbor = neighbor_indices_[index][i];
+    for (int i = 0; i < tables_->neighbor_counts[index]; ++i) {
+        int neighbor = tables_->neighbor_indices[index][i];
         int8_t v = board_[neighbor];
         if (v == EMPTY) {
             has_empty_neighbor = true;
@@ -195,10 +204,10 @@ bool GoBoard::is_legal_flat(int index) const {
     bool need_suicide_check = !has_empty_neighbor && !captures_opponent;
     bool need_psk_check = !seen_hashes_.empty();
     if (need_suicide_check || need_psk_check) {
-        GoBoard tmp(*this);
-        // Don't pay for copying seen_hashes_ on the simulation path;
-        // we only need the resulting hash + occupancy at `index`.
-        tmp.seen_hashes_.clear();
+        // Lightweight clone: skips copy-constructing (then discarding)
+        // the whole seen_hashes_ set. We only need the resulting hash +
+        // occupancy at `index`; PSK is checked against *this's history.
+        GoBoard tmp(*this, SimClone{});
         tmp.play_flat_unchecked(index);
         // (a) Multi-stone suicide: play_flat_unchecked's self-capture
         // branch removes our group when it has no liberties post-move,
@@ -252,7 +261,7 @@ void GoBoard::play_flat_unchecked(int index) {
 
     // Place the stone (and update the running hash).
     board_[index] = to_play_;
-    current_hash_ ^= zobrist_[index][to_play_];
+    current_hash_ ^= tables_->zobrist[index][to_play_];
     int8_t opponent = (to_play_ == BLACK) ? WHITE : BLACK;
 
     // Reset ko point
@@ -262,8 +271,8 @@ void GoBoard::play_flat_unchecked(int index) {
     int total_captured = 0;
     int last_captured_idx = -1;
 
-    for (int i = 0; i < neighbor_counts_[index]; ++i) {
-        int neighbor = neighbor_indices_[index][i];
+    for (int i = 0; i < tables_->neighbor_counts[index]; ++i) {
+        int neighbor = tables_->neighbor_indices[index][i];
         if (board_[neighbor] == opponent) {
             auto [group, liberties] = get_group_and_liberties(neighbor);
             if (liberties.empty()) {
@@ -353,8 +362,8 @@ float GoBoard::score() const {
             queue.pop();
             territory.push_back(current);
 
-            for (int j = 0; j < neighbor_counts_[current]; ++j) {
-                int neighbor = neighbor_indices_[current][j];
+            for (int j = 0; j < tables_->neighbor_counts[current]; ++j) {
+                int neighbor = tables_->neighbor_indices[current][j];
                 if (board_[neighbor] == EMPTY) {
                     if (!visited[neighbor]) {
                         visited[neighbor] = true;
@@ -401,7 +410,7 @@ void GoBoard::set_from_array(const int8_t* board_data, int8_t to_play) {
     for (int i = 0; i < size_ * size_; ++i) {
         board_[i] = board_data[i];
         if (board_[i] != EMPTY) {
-            current_hash_ ^= zobrist_[i][board_[i]];
+            current_hash_ ^= tables_->zobrist[i][board_[i]];
         }
     }
     seen_hashes_.clear();

--- a/src/alpha_go/cpp/go/go_game.h
+++ b/src/alpha_go/cpp/go/go_game.h
@@ -9,6 +9,28 @@
 
 namespace alpha_go {
 
+// Immutable, board-size-only lookup tables. These depend solely on
+// `size` and never change after construction, yet a GoBoard is copied
+// constantly (every PSK legality simulation, every MCTS node expansion,
+// every rollout step, and once per tree node by value). Storing them
+// per-instance meant every copy memcpy'd ~3.5 KB of constant data and
+// did 3 heap allocations. Sharing one cached instance per size makes a
+// GoBoard copy just copy the 81-byte board + scalars + a pointer.
+struct BoardTables {
+    // neighbor_indices[i] holds the flat indices of cell i's neighbors;
+    // neighbor_counts[i] is how many are valid (1-4, board edges/corners).
+    std::vector<std::array<int, 4>> neighbor_indices;
+    std::vector<int> neighbor_counts;
+    // zobrist[i][color] is a fixed random 64-bit value per (position,
+    // color). Deterministic per size so equal boards hash identically.
+    std::vector<std::array<uint64_t, 3>> zobrist;
+};
+
+// Returns the process-wide cached tables for a given board size,
+// building them on first use. The reference is stable for the program
+// lifetime, so GoBoard can safely hold a raw pointer into it.
+const BoardTables& board_tables(int size);
+
 // Board representation: flat array for cache efficiency
 // Values: 0=EMPTY, 1=BLACK, 2=WHITE
 class GoBoard {
@@ -63,9 +85,6 @@ public:
     void set_from_array(const int8_t* board_data, int8_t to_play);
 
 private:
-    void init_neighbors();
-    void init_zobrist();              // Fill zobrist_ with deterministic values
-
     // Flood-fill to find connected group and its liberties
     // Returns (group_indices, liberty_indices)
     std::pair<std::vector<int>, std::vector<int>> get_group_and_liberties(int index) const;
@@ -80,6 +99,18 @@ private:
     // and ALSO inserts the pre-move hash into seen_hashes_.
     void play_flat_unchecked(int index);
 
+    // Lightweight copy for the is_legal_flat PSK/suicide simulation:
+    // everything except seen_hashes_, which is_legal_flat would clear
+    // anyway. Avoids copy-constructing (then discarding) the whole
+    // seen_hashes_ set on every legality check past move 1.
+    struct SimClone {};
+    GoBoard(const GoBoard& o, SimClone)
+        : size_(o.size_), komi_(o.komi_), board_(o.board_),
+          to_play_(o.to_play_), ko_point_(o.ko_point_),
+          consecutive_passes_(o.consecutive_passes_),
+          move_count_(o.move_count_), tables_(o.tables_),
+          current_hash_(o.current_hash_) {}
+
     int size_;
     float komi_;
     std::vector<int8_t> board_;       // size_ * size_
@@ -88,22 +119,21 @@ private:
     int consecutive_passes_ = 0;
     int move_count_ = 0;
 
-    // Pre-computed neighbors (4 neighbors per cell max)
-    // neighbor_indices_[i] contains the flat indices of neighbors of cell i
-    // neighbor_counts_[i] is the number of valid neighbors (1-4)
-    std::vector<std::array<int, 4>> neighbor_indices_;
-    std::vector<int> neighbor_counts_;
+    // Shared, immutable, size-only lookup tables (neighbors + zobrist).
+    // Points into a process-wide cache (see board_tables()); never owned,
+    // never freed by GoBoard. Copying a GoBoard just copies this pointer.
+    const BoardTables* tables_;
 
     // Positional superko (PSK) state.
     //
-    // - zobrist_[color][index] is a per-(color, position) random 64-bit
-    //   value, fixed at construction (deterministic seed). The current
-    //   board hash is the XOR of zobrist_[board_[i]][i] over all
+    // - tables_->zobrist[index][color] is a per-(position, color) random
+    //   64-bit value, fixed per board size (deterministic). The current
+    //   board hash is the XOR of tables_->zobrist[i][board_[i]] over all
     //   non-empty positions (color codes 1=BLACK, 2=WHITE; we ignore
     //   slot 0).
     // - current_hash_ is incrementally maintained: every stone placement
-    //   XORs in zobrist_[player][p]; every capture XORs out
-    //   zobrist_[stone][p].
+    //   XORs in zobrist[p][player]; every capture XORs out
+    //   zobrist[p][stone].
     // - seen_hashes_ is the set of hashes for board states reached
     //   *before* the current state (positions B0, B1, ..., B_{n-1} when
     //   the current state is Bn). is_legal_flat rejects any move whose
@@ -111,7 +141,6 @@ private:
     //   A pass leaves the board unchanged so the resulting hash equals
     //   current_hash_ (which is NOT in seen_hashes_ until the NEXT move
     //   adds it), so passing is always legal under PSK as expected.
-    std::vector<std::array<uint64_t, 3>> zobrist_;
     uint64_t current_hash_ = 0;
     std::unordered_set<uint64_t> seen_hashes_;
 };


### PR DESCRIPTION
## Summary

`GoBoard` stored `neighbor_indices_`, `neighbor_counts_`, and `zobrist_` **per instance**. These depend only on board size and never change after construction — but `GoBoard` is copied constantly:

- every `is_legal_flat` PSK/suicide simulation (`GoBoard tmp(*this)`, fires on essentially every move past move 1),
- every MCTS node expansion (`GoBoard new_state = node.state`, both the recursive and leaf-parallel paths),
- every `fast_rollout` step,
- once by value per MCTS tree node (`nodes_.emplace_back(state)`).

Each copy memcpy'd ~3.5 KB of constant data and did 3 heap allocations, all to reproduce identical size-only tables.

## Change (no behavior change)

1. **Share the tables.** Move neighbors + zobrist into a `BoardTables` struct built once per size by a process-wide cache (`board_tables(size)`); `GoBoard` holds a `const BoardTables*`. A copy now duplicates only the 81-byte `board_` + scalars + a pointer. A per-size static cache is used rather than `shared_ptr` to avoid an atomic refcount bump on every copy — only sizes 9 and 19 are ever constructed in this codebase, and the cached reference is stable for the program lifetime.
2. **Skip the wasted `seen_hashes_` copy.** `is_legal_flat` copy-constructed the entire `seen_hashes_` set and then immediately `.clear()`-ed it on the temporary. A private `SimClone` constructor skips it — PSK is still checked against `*this`'s history, not the temporary's.

Hashes, neighbors, and legality are bit-for-bit identical; this is purely a copy/allocation reduction.

## Correctness

- C++ unit tests: `All tests passed (143 assertions in 18 test cases)`.
- Full Python suite: **101 passed, 24 skipped** (skips are GPU/checkpoint-gated) — identical to clean `main`. `test_gpu_lease.py` excluded only for the pre-existing collection failure tracked in #6, unrelated here.

## Benchmark

The official `experiments/.../benchmark.py` needs GPU + torch + a checkpoint and can't run on macOS, so I used a CPU-only micro-bench with a trivial Python evaluator — the before/after delta therefore reflects **board/tree CPU cost only** (the part this PR touches; the NN evaluator is untouched and would dominate a GPU run, so the real-world self-play gain is a fraction of this but free).

Measured on macOS, Release build, 9x9, mean of 3 runs, before = clean `origin/main`:

| | clean main | this PR | delta |
|---|---|---|---|
| `copy + is_legal_flat` | ~335K ops/s | ~487K ops/s | **+45%** |
| C++ MCTS sims/sec | ~6,490 | ~8,932 | **+37.6%** |
| wall time, 115,200 sims | ~17.75s | ~12.90s | **−27%** |

Reproduce (no GPU/torch needed) — save as `agobench.py`, build the extension, run before and after this branch:

```python
import random, time, alpha_go_cpp
PASS, SIZE = alpha_go_cpp.PASS_ACTION, 9

def uniform_eval(b):
    m = b.get_legal_moves_flat(); p = 1.0/(len(m)+1)
    d = {x: p for x in m}; d[PASS] = p; return d, 0.5

def midgame(n=40, seed=0):
    rng = random.Random(seed); b = alpha_go_cpp.GoBoard(SIZE, 7.5)
    for _ in range(n):
        if b.is_game_over(): break
        legal = b.get_legal_moves_flat()
        b.play_flat(rng.choice(legal)) if legal else b.pass_move()
    return b

def bench_copy(iters=200_000):
    b = midgame(); t0 = time.perf_counter()
    for i in range(iters):
        c = b.copy(); c.is_legal_flat(i % (SIZE*SIZE))
    return iters / (time.perf_counter() - t0)

def bench_mcts(games=12, sims=160, max_moves=60):
    cfg = alpha_go_cpp.MCTSConfig(); cfg.c_puct = 1.0
    n = 0; t0 = time.perf_counter()
    for _ in range(games):
        b = alpha_go_cpp.GoBoard(SIZE, 7.5); mv = 0
        while not b.is_game_over() and mv < max_moves:
            t = alpha_go_cpp.MCTSTree(b, cfg); t.run_simulations(sims, uniform_eval)
            n += sims; a = t.select_action(0.0)
            if a == PASS: b.pass_move()
            else:
                r, c = b.row_col(a)
                b.play(r, c) or b.pass_move()
            mv += 1
    return n / (time.perf_counter() - t0)

bench_copy(5000)
print(f"copy+is_legal : {bench_copy():,.0f} ops/sec")
print(f"mcts          : {bench_mcts():,.0f} sims/sec")
```

Single-purpose diff: only `src/alpha_go/cpp/go/go_game.{h,cpp}`. Independent of #5/#6/#7/#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
